### PR TITLE
New detector CompareClassNameEquals

### DIFF
--- a/etc/findbugs.xml
+++ b/etc/findbugs.xml
@@ -229,6 +229,8 @@
 	<Detector class="com.mebigfatguy.fbcontrib.detect.CommonsHashcodeBuilderToHashcode" speed="fast" reports="CHTH_COMMONS_HASHCODE_BUILDER_TOHASHCODE" />
 	
 	<Detector class="com.mebigfatguy.fbcontrib.detect.CommonsStringBuilderToString" speed="fast" reports="CSBTS_COMMONS_STRING_BUILDER_TOSTRING" />
+	
+	<Detector class="com.mebigfatguy.fbcontrib.detect.CompareClassNameEquals" speed="fast" reports="CCNE_COMPARE_CLASS_EQUALS_NAME" />
 
 	<!-- BugPattern -->
 
@@ -400,4 +402,5 @@
 	<BugPattern abbrev="CEBE" type="CEBE_COMMONS_EQUALS_BUILDER_ISEQUALS" category="CORRECTNESS" />
 	<BugPattern abbrev="CHTH" type="CHTH_COMMONS_HASHCODE_BUILDER_TOHASHCODE" category="CORRECTNESS" />
 	<BugPattern abbrev="CSBTS" type="CSBTS_COMMONS_STRING_BUILDER_TOSTRING" category="CORRECTNESS" />
+	<BugPattern abbrev="CCNE" type="CCNE_COMPARE_CLASS_EQUALS_NAME" category="CORRECTNESS" />
 </FindbugsPlugin>

--- a/etc/messages.xml
+++ b/etc/messages.xml
@@ -1247,6 +1247,19 @@
         </Details>
     </Detector>
     
+    <Detector class="com.mebigfatguy.fbcontrib.detect.CompareClassNameEquals">
+        <Details>
+            <![CDATA[
+            <p> In a JVM, Two classes are the same class (and consequently the same type) if
+            they are loaded by the same class loader, and they have the same fully
+            qualified name [JVMSpec 1999].
+            
+            Comparing class name ignores the class loader.
+            </p>
+            ]]>
+        </Details>
+    </Detector>
+    
 	<!-- BugPattern -->
 
 	<BugPattern type="ISB_INEFFICIENT_STRING_BUFFERING">
@@ -3402,6 +3415,21 @@
             ]]>
         </Details>
     </BugPattern>
+    
+    <BugPattern type="CCNE_COMPARE_CLASS_EQUALS_NAME">
+        <ShortDescription>Method compare class name instead of comparing class</ShortDescription>
+        <LongDescription>Method {1} compares class name instead of comparing the class</LongDescription>
+        <Details>
+            <![CDATA[
+            <p> In a JVM, Two classes are the same class (and consequently the same type) if
+            they are loaded by the same class loader, and they have the same fully
+            qualified name [JVMSpec 1999].
+            
+            Comparing class name ignores the class loader.
+            </p>
+            ]]>
+        </Details>
+    </BugPattern>
         
 	<!-- BugCode -->
 
@@ -3508,4 +3536,5 @@
 	<BugCode abbrev="CEBE">Commons EqualsBuilder To Equals</BugCode>
 	<BugCode abbrev="CHTH">Commons HashCodeBuilder To hashCode</BugCode>
 	<BugCode abbrev="CSBTS">Commons ToStringBuilder To String</BugCode>
+    <BugCode abbrev="CCNE">Compare class name equals</BugCode>
 </MessageCollection>

--- a/samples/CCNE_Sample.java
+++ b/samples/CCNE_Sample.java
@@ -1,0 +1,8 @@
+public class CCNE_Sample {
+    public void compareClassEquals() {
+        Object o = new CCNE_Sample();
+        Object p = new CCNE_Sample();
+        System.out.println(o.getClass().getName()
+                .equals(p.getClass().getName()));
+    }
+}

--- a/src/com/mebigfatguy/fbcontrib/detect/CompareClassNameEquals.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/CompareClassNameEquals.java
@@ -1,0 +1,71 @@
+package com.mebigfatguy.fbcontrib.detect;
+
+import org.apache.bcel.classfile.Code;
+import org.apache.bcel.classfile.LocalVariableTable;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.OpcodeStack.Item;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+
+/**
+ * In a JVM, Two classes are the same class (and consequently the same type) if
+ * they are loaded by the same class loader, and they have the same fully
+ * qualified name [JVMSpec 1999].
+ * 
+ * Two classes with the same name but different package names are distinct, as
+ * are two classes with the same fully qualified name loaded by different class
+ * loaders.
+ * 
+ * Find usage involving comparison of class names, rather than the class itself.
+ * 
+ */
+public class CompareClassNameEquals extends OpcodeStackDetector {
+    private boolean flag = false;
+    private final BugReporter bugReporter;
+
+    public CompareClassNameEquals(final BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public boolean shouldVisitCode(Code obj) {
+        flag = false;
+        LocalVariableTable lvt = getMethod().getLocalVariableTable();
+        return lvt != null;
+    }
+
+    @Override
+    public void afterOpcode(int seen) {
+        super.afterOpcode(seen);
+        if (flag == true) {
+            stack.getStackItem(0).setUserValue(Boolean.TRUE);
+            flag = false;
+        }
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        switch (seen) {
+        case INVOKEVIRTUAL:
+            if ("getName".equals(getNameConstantOperand())
+                    && "()Ljava/lang/String;".equals(getSigConstantOperand())
+                    && "java/lang/Class".equals(getClassConstantOperand())) {
+                flag = true;
+            } else if ("equals".equals(getNameConstantOperand())
+                    && "(Ljava/lang/Object;)Z".equals(getSigConstantOperand())
+                    && "java/lang/String".equals(getClassConstantOperand())) {
+                Item item = stack.getItemMethodInvokedOn(this);
+                Object userValue = item.getUserValue();
+                if (userValue != null && userValue == Boolean.TRUE) {
+                    bugReporter
+                            .reportBug(new BugInstance(this,
+                                    "CCNE_COMPARE_CLASS_EQUALS_NAME",
+                                    NORMAL_PRIORITY).addClass(this)
+                                    .addMethod(this).addSourceLine(this));
+                }
+            }
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Detector that looks for (getClass().getName().equals(other.getClass().getName()) rather than performing getClass() == other.getClass()

The sample written seems to cause an exception in InefficientStringBuffering which needs to be looked into,
