### PR TITLE
Added new detector BackportReusePublicIdentifiers

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry excluding="**/*.*" kind="src" path="etc"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="samples"/>
+	<classpathentry excluding="lib/" kind="src" path="samples"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="lib/annotations-2.0.0.jar"/>
@@ -14,5 +14,6 @@
 	<classpathentry kind="lib" path="samples/lib/junit-4.10.jar"/>
 	<classpathentry kind="lib" path="samples/lib/log4j-1.2.16.jar"/>
 	<classpathentry kind="lib" path="samples/lib/servlet-api-3.0.1.jar"/>
+	<classpathentry kind="lib" path="samples/lib/backport-util-concurrent-3.1.jar"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -27,23 +27,25 @@
 	<property name="annotations.version" value="2.0.0"/>
 	<property name="asm-tree.version" value="3.3.1"/>
 	
-        <property name="findbugs-url" value="http://repo1.maven.org/maven2/com/google/code/findbugs/findbugs/${findbugs.version}/findbugs-${findbugs.version}.jar"/> 
-        <property name="findbugs-bcel-url" value="http://repo1.maven.org/maven2/com/google/code/findbugs/bcel/${findbugs-bcel.version}/bcel-${findbugs-bcel.version}.jar"/> 
-        <property name="annotations-url" value="http://repo1.maven.org/maven2/com/google/code/findbugs/annotations/${annotations.version}/annotations-${annotations.version}.jar"/> 
-        <property name="asm-tree-url" value="http://repo1.maven.org/maven2/asm/asm-tree/${asm-tree.version}/asm-tree-${asm-tree.version}.jar"/> 
+    <property name="findbugs-url" value="http://repo1.maven.org/maven2/com/google/code/findbugs/findbugs/${findbugs.version}/findbugs-${findbugs.version}.jar"/> 
+    <property name="findbugs-bcel-url" value="http://repo1.maven.org/maven2/com/google/code/findbugs/bcel/${findbugs-bcel.version}/bcel-${findbugs-bcel.version}.jar"/> 
+    <property name="annotations-url" value="http://repo1.maven.org/maven2/com/google/code/findbugs/annotations/${annotations.version}/annotations-${annotations.version}.jar"/> 
+    <property name="asm-tree-url" value="http://repo1.maven.org/maven2/asm/asm-tree/${asm-tree.version}/asm-tree-${asm-tree.version}.jar"/> 
 
-       <!-- properties for samples lib dependencies -->
-       <property name="commons-lang3.version" value="3.1"/>
-       <property name="jsp-api.version" value="2.2.1" />
-       <property name="junit.version" value="4.10" />
-       <property name="log4j.version" value="1.2.16" />
-       <property name="servlet-api.version" value="3.0.1" />
+    <!-- properties for samples lib dependencies -->
+    <property name="commons-lang3.version" value="3.1"/>
+    <property name="jsp-api.version" value="2.2.1" />
+    <property name="junit.version" value="4.10" />
+    <property name="log4j.version" value="1.2.16" />
+    <property name="servlet-api.version" value="3.0.1" />
+    <property name="backport-concurrent.version" value="3.1" />
 
-       <property name="commons-lang3-url" value="http://repo1.maven.org/maven2/org/apache/commons/commons-lang3/${commons-lang3.version}/commons-lang3-${commons-lang3.version}.jar"/> 
-       <property name="jsp-api-url" value="http://repo1.maven.org/maven2/javax/servlet/jsp/javax.servlet.jsp-api/${jsp-api.version}/javax.servlet.jsp-api-${jsp-api.version}.jar" />
-       <property name="junit-url" value="http://repo1.maven.org/maven2/junit/junit/${junit.version}/junit-${junit.version}.jar"/> 
-       <property name="log4j-url" value="http://repo1.maven.org/maven2/log4j/log4j/${log4j.version}/log4j-${log4j.version}.jar"/> 
-       <property name="servlet-api-url" value="http://repo1.maven.org/maven2/javax/servlet/javax.servlet-api/${servlet-api.version}/javax.servlet-api-${servlet-api.version}.jar"/> 
+    <property name="commons-lang3-url" value="http://repo1.maven.org/maven2/org/apache/commons/commons-lang3/${commons-lang3.version}/commons-lang3-${commons-lang3.version}.jar"/> 
+    <property name="jsp-api-url" value="http://repo1.maven.org/maven2/javax/servlet/jsp/javax.servlet.jsp-api/${jsp-api.version}/javax.servlet.jsp-api-${jsp-api.version}.jar" />
+    <property name="junit-url" value="http://repo1.maven.org/maven2/junit/junit/${junit.version}/junit-${junit.version}.jar"/> 
+    <property name="log4j-url" value="http://repo1.maven.org/maven2/log4j/log4j/${log4j.version}/log4j-${log4j.version}.jar"/> 
+    <property name="servlet-api-url" value="http://repo1.maven.org/maven2/javax/servlet/javax.servlet-api/${servlet-api.version}/javax.servlet-api-${servlet-api.version}.jar"/>
+	<property name="backport-concurrent-url" value="http://repo1.maven.org/maven2/backport-util-concurrent/backport-util-concurrent/${backport-concurrent.version}/backport-util-concurrent-${backport-concurrent.version}.jar" />
 
 	<target name="clean" description="removes all generated collateral">
 		<delete dir="${classes.dir}"/>
@@ -76,6 +78,8 @@
 			<pathelement location="${sampleslib.dir}/servlet-api-${servlet-api.version}.jar"/>
 			<pathelement location="${sampleslib.dir}/log4j-${log4j.version}.jar"/>
 			<pathelement location="${sampleslib.dir}/commons-lang3-${commons-lang3.version}.jar"/>
+			<pathelement location="${sampleslib.dir}/commons-lang3-${commons-lang3.version}.jar"/>
+			<pathelement location="${sampleslib.dir}/backport-util-concurrent-${backport-concurrent.version}.jar"/>
 		</path>
 		<mkdir dir="${classes.dir}/com"/>
 		<mkdir dir="${classes.dir}/com/mebigfatguy"/>
@@ -107,6 +111,10 @@
     <target name="servlet-api-check">
         <available file="${basedir}/samples/lib/servlet-api-${servlet-api.version}.jar" property="servlet-api-exists"/>
     </target>
+	
+	<target name="backport-concurrent-check">
+		<available file="${basedir}/samples/lib/backport-util-concurrent-${backport-concurrent.version}.jar" property="backport-concurrent-exists" />
+	</target>
 
     <target name="jsp-api-check">
         <available file="${basedir}/samples/lib/jsp-api-${jsp-api.version}.jar" property="jsp-api-exists"/>
@@ -143,7 +151,11 @@
     <target name="install-servlet-api" depends="servlet-api-check" unless="servlet-api-exists" description="installs servlet-api into samples/lib">
         <get src="${servlet-api-url}" dest="${basedir}/samples/lib/servlet-api-${servlet-api.version}.jar" verbose="true" ignoreerrors="true"/>
     </target>
-
+    
+	<target name="install-backport-concurrent" depends="backport-concurrent-check" unless="backport-concurrent-exists" description="installs backport-concurrent into samples/lib">
+        <get src="${backport-concurrent-url}" dest="${basedir}/samples/lib/backport-util-concurrent-${backport-concurrent.version}.jar" verbose="true" ignoreerrors="true"/>
+    </target>	
+	
     <target name="install-jsp-api" depends="jsp-api-check" unless="jsp-api-exists" description="installs jsp-api into samples/lib">
         <get src="${jsp-api-url}" dest="${basedir}/samples/lib/jsp-api-${jsp-api.version}.jar" verbose="true" ignoreerrors="true"/>
     </target>
@@ -156,7 +168,7 @@
         <get src="${junit-url}" dest="${basedir}/samples/lib/junit-${junit.version}.jar" verbose="true" ignoreerrors="true"/>
     </target>
 
-    <target name="pull" depends="install-findbugs, install-findbugs-bcel, install-annotations, install-asm-tree, install-commons-lang3, install-servlet-api, install-jsp-api, install-log4j, install-junit" description="pull 3rdparty jars to the lib directory"/>
+    <target name="pull" depends="install-findbugs, install-findbugs-bcel, install-annotations, install-asm-tree, install-commons-lang3, install-servlet-api, install-backport-concurrent, install-jsp-api, install-log4j, install-junit" description="pull 3rdparty jars to the lib directory"/>
 
 	<target name="validate_xml" depends="-init" description="validates the xml files">
 		<xmlvalidate lenient="false" failonerror="yes">

--- a/etc/findbugs.xml
+++ b/etc/findbugs.xml
@@ -231,6 +231,8 @@
 	<Detector class="com.mebigfatguy.fbcontrib.detect.CommonsStringBuilderToString" speed="fast" reports="CSBTS_COMMONS_STRING_BUILDER_TOSTRING" />
 	
 	<Detector class="com.mebigfatguy.fbcontrib.detect.CompareClassNameEquals" speed="fast" reports="CCNE_COMPARE_CLASS_EQUALS_NAME" />
+	
+	<Detector class="com.mebigfatguy.fbcontrib.detect.BackportReusePublicIdentifiers" speed="fast" reports="BRPI_BACKPORT_REUSE_PUBLIC_IDENTIFIERS" />
 
 	<!-- BugPattern -->
 
@@ -403,4 +405,5 @@
 	<BugPattern abbrev="CHTH" type="CHTH_COMMONS_HASHCODE_BUILDER_TOHASHCODE" category="CORRECTNESS" />
 	<BugPattern abbrev="CSBTS" type="CSBTS_COMMONS_STRING_BUILDER_TOSTRING" category="CORRECTNESS" />
 	<BugPattern abbrev="CCNE" type="CCNE_COMPARE_CLASS_EQUALS_NAME" category="CORRECTNESS" />
+	<BugPattern abbrev="BRPI" type="BRPI_BACKPORT_REUSE_PUBLIC_IDENTIFIERS" category ="PERFORMANCE" />
 </FindbugsPlugin>

--- a/etc/messages.xml
+++ b/etc/messages.xml
@@ -1260,6 +1260,17 @@
         </Details>
     </Detector>
     
+    <Detector class="com.mebigfatguy.fbcontrib.detect.BackportReusePublicIdentifiers">
+        <Details>
+            <![CDATA[
+            <p> Detects use of Backport Utils concurrent classes. Updated/Efficient version of these
+            classes are available in versions of the JDK 5.0 and higher, and these
+            classes should only be used if you are targeting JDK 1.4 and lower.
+            </p>
+            ]]>
+        </Details>
+    </Detector>
+    
 	<!-- BugPattern -->
 
 	<BugPattern type="ISB_INEFFICIENT_STRING_BUFFERING">
@@ -3417,7 +3428,7 @@
     </BugPattern>
     
     <BugPattern type="CCNE_COMPARE_CLASS_EQUALS_NAME">
-        <ShortDescription>Method compare class name instead of comparing class</ShortDescription>
+        <ShortDescription>Method compares class name instead of comparing class</ShortDescription>
         <LongDescription>Method {1} compares class name instead of comparing the class</LongDescription>
         <Details>
             <![CDATA[
@@ -3426,6 +3437,19 @@
             qualified name [JVMSpec 1999].
             
             Comparing class name ignores the class loader.
+            </p>
+            ]]>
+        </Details>
+    </BugPattern>
+    
+    <BugPattern type="BRPI_BACKPORT_REUSE_PUBLIC_IDENTIFIERS">
+        <ShortDescription>Method uses backport concurrency utils</ShortDescription>
+        <LongDescription>Method {1} backport concurrency utils</LongDescription>
+        <Details>
+            <![CDATA[
+            <p> Detects use of Backport Utils concurrent classes. Updated/Efficient version of these
+            classes are available in versions of the JDK 5.0 and higher, and these
+            classes should only be used if you are targeting JDK 1.4 and lower.
             </p>
             ]]>
         </Details>
@@ -3537,4 +3561,5 @@
 	<BugCode abbrev="CHTH">Commons HashCodeBuilder To hashCode</BugCode>
 	<BugCode abbrev="CSBTS">Commons ToStringBuilder To String</BugCode>
     <BugCode abbrev="CCNE">Compare class name equals</BugCode>
+    <BugCode abbrev="BRPI">Backport concurrent reuse of public identifiers</BugCode>
 </MessageCollection>

--- a/samples.xml
+++ b/samples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<BugCollection version="2.0.0" sequence="0" timestamp="1326913749000" analysisTimestamp="1326914562879" release="">
+<BugCollection version="2.0.0" sequence="0" timestamp="1328194198000" analysisTimestamp="1328194339381" release="">
   <Project projectName="Samples">
     <Jar>/home/bhaskar/workspace/fb2/fb-contrib/samples</Jar>
     <AuxClasspathEntry>/home/bhaskar/workspace/fb2/fb-contrib/samples/lib/commons-lang3-3.1.jar</AuxClasspathEntry>
@@ -8,15 +8,8 @@
     <AuxClasspathEntry>/home/bhaskar/workspace/fb2/fb-contrib/samples/lib/junit-4.10.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/home/bhaskar/workspace/fb2/fb-contrib/samples/lib/log4j-1.2.16.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/home/bhaskar/workspace/fb2/fb-contrib/samples/lib/servlet-api-3.0.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/home/bhaskar/workspace/fb2/fb-contrib/samples/lib/backport-util-concurrent-3.1.jar</AuxClasspathEntry>
     <SrcDir>/home/bhaskar/workspace/fb2/fb-contrib/samples</SrcDir>
     <WrkDir>/home/bhaskar/workspace/fb2/fb-contrib</WrkDir>
   </Project>
-  <Errors errors="0" missingClasses="0"></Errors>
-  <FindBugsSummary timestamp="Thu, 26 Jan 2012 13:23:04 -0800" total_classes="0" referenced_classes="0" total_bugs="0" total_size="0" num_packages="1" vm_version="20.0-b11" cpu_seconds="61.07" clock_seconds="30.03" peak_mbytes="376.02" alloc_mbytes="1214.25" gc_seconds="0.62">
-    <FindBugsProfile>
-      <ClassProfile name="edu.umd.cs.findbugs.SAXBugCollectionHandler" totalMilliseconds="21" invocations="1" avgMicrosecondsPerInvocation="21291" maxMicrosecondsPerInvocation="21291" standardDeviationMircosecondsPerInvocation="0"/>
-    </FindBugsProfile>
-  </FindBugsSummary>
-  <ClassFeatures></ClassFeatures>
-  <History></History>
 </BugCollection>

--- a/samples/BRPI_Sample.java
+++ b/samples/BRPI_Sample.java
@@ -1,0 +1,11 @@
+import edu.emory.mathcs.backport.java.util.Collections;
+import edu.emory.mathcs.backport.java.util.concurrent.ConcurrentHashMap;
+import edu.emory.mathcs.backport.java.util.concurrent.Executors;
+
+public class BRPI_Sample {
+    public static void main(String[] arg) {
+        Collections.emptySet();
+        Executors.newCachedThreadPool();
+        new ConcurrentHashMap();
+    }
+}

--- a/src/com/mebigfatguy/fbcontrib/detect/BackportReusePublicIdentifiers.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/BackportReusePublicIdentifiers.java
@@ -1,0 +1,49 @@
+package com.mebigfatguy.fbcontrib.detect;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+
+/**
+ * Detects use of Backport concurrent classes. Updated/Efficient version of
+ * these classes are available in versions of the JDK 5.0 and higher, and these
+ * classes should only be used if you are targeting JDK 1.4 and lower.
+ * 
+ * Finds usage of classes from backport utils package.
+ */
+public class BackportReusePublicIdentifiers extends OpcodeStackDetector {
+
+    private final BugReporter bugReporter;
+
+    public BackportReusePublicIdentifiers(final BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        switch (seen) {
+        case INVOKESTATIC: {
+            String className = getClassConstantOperand();
+            if (className.startsWith("edu/emory/mathcs/backport/")) {
+                reportBug();
+            }
+        }
+            break;
+        case INVOKESPECIAL: {
+            String className = getClassConstantOperand();
+            String methodName = getNameConstantOperand();
+            if (className.startsWith("edu/emory/mathcs/backport/")
+                    && methodName.equals("<init>")) {
+                reportBug();
+            }
+        }
+            break;
+        }
+    }
+
+    private void reportBug() {
+        bugReporter.reportBug(new BugInstance(this,
+                "BRPI_BACKPORT_REUSE_PUBLIC_IDENTIFIERS", NORMAL_PRIORITY)
+                .addClass(this).addMethod(this).addSourceLine(this));
+    }
+}


### PR DESCRIPTION
Detects use of Backport concurrent classes. Updated/Efficient version of these classes are available in versions of the JDK 5.0 and higher, and these classes should only be used if you are targeting JDK 1.4 and lower.
