### PR TITLE
Fix placeholder for MDM_WAIT_WITHOUT_TIMEOUT

### DIFF
--- a/etc/messages.xml
+++ b/etc/messages.xml
@@ -3601,7 +3601,7 @@
 		<LongDescription>Method {1} sleeps without timeout when calling {2}</LongDescription>
 		<Details>
 			<![CDATA[
-			<p>Calling <code>{2}</code> without timeout could block forever. Consider using a timeout to detect deadlocks or performance problems. Thread.join() Object.wait() Condition.await() Lock.lock() Lock.lockInterruptibly()</p>
+			<p>Calling one of the following methods without timeout could block forever. Consider using a timeout to detect deadlocks or performance problems. Methods: Thread.join(), Object.wait(), Condition.await(), Lock.lock(), Lock.lockInterruptibly(), ReentrantLock.lock(), ReentrantLock.lockInterruptibly()</p>
 			]]>
 		</Details>
 	</BugPattern>


### PR DESCRIPTION
There was a message format placeholder in detailed message for pattern
MDM_WAIT_WITHOUT_TIMEOUT although placeholders are not replaced in the
detailed messages. Therefore the placeholder showed up in the reports.

Also commas and two missing methods were added to the list in message.
