### PR TITLE
Bug fixes in UseCharacterParameterizedMethod

### DIFF
--- a/samples/AIOB_Sample.java
+++ b/samples/AIOB_Sample.java
@@ -10,6 +10,14 @@ public class AIOB_Sample {
         a[4] = 2;
         fa[4] = 2;
     }
+    
+    public void testOutOfBoundsGuard() {
+        int[] a = new int[4];
+
+        if (a.length > 4){
+            a[4] = 2;
+        }
+    }
 
     public void testUnallocated() {
         int[] b = null;

--- a/samples/UCPM_Sample.java
+++ b/samples/UCPM_Sample.java
@@ -1,9 +1,60 @@
+
 public class UCPM_Sample {
-    public int testUcpm1(String s) {
-        return s.indexOf("*") * 10;
+    
+    private StringBuffer sb;		//made this a field to avoid "unnecessary use of synchronized class"	
+
+    public int test(String foo) {		
+    	sb = new StringBuffer();
+    	//no tag
+    	sb.append('f');
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD 
+    	sb.append("f");
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD 
+    	sb.append("f").append("o");	
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD 
+    	sb.append('f').append("o");	
+    	
+    	
+    	StringBuilder sb2 = new StringBuilder();	
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD 
+    	sb2.append("g");		
+    	//no tag
+    	sb2.append('g');		
+
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD 
+    	System.out.println(foo.replace(".", ","));	
+    	
+    	//no tag
+    	System.out.println(foo.replace(".", ".."));	
+    	//no tag
+    	System.out.println(foo.replace("..", ","));	    	
+    	//no tag
+    	System.out.println(foo.replace('.', ','));		
+
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD 
+    	System.out.println(foo.lastIndexOf("."));	
+    	//no tag
+    	System.out.println(foo.lastIndexOf('.'));	
+    	
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD 
+    	return foo.indexOf("*") * 10;
+
     }
 
     public String testUcpm2(String s) {
+    	//here to prevent a "used only as locals" bug notification
+    	System.out.println(sb);
+    	
+    	//tag UCPM_USE_CHARACTER_PARAMETERIZED_METHOD
+    	System.out.println(s + ":" + s);
+    	
+    	//no tag, the compiler usually optimizes this by concatenating "a" and "b" into a "ab"
+    	System.out.println("a" + "b" + s);
+    	//no tag
+    	System.out.println(s + " : " + s);
+    	
+    	
+    	//no tag, starts with doesn't have a char equivalent 
         return s.startsWith("*") ? s.substring(1) : s;
     }
 }

--- a/src/com/mebigfatguy/fbcontrib/detect/UseCharacterParameterizedMethod.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/UseCharacterParameterizedMethod.java
@@ -19,6 +19,7 @@
 package com.mebigfatguy.fbcontrib.detect;
 
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,22 +39,38 @@ import edu.umd.cs.findbugs.ba.ClassContext;
 /**
  * looks for methods that pass single character string constants as parameters to 
  * methods that alternatively have an overridden method that accepts a character instead.
- * It is easier for the method to handle a single character than a String.
+ * It is more performant for the method to handle a single character than a String.
  */
 public class UseCharacterParameterizedMethod extends BytecodeScanningDetector 
 {
-	private static Map<String, Integer> characterMethods = new HashMap<String, Integer>();
+	public final static Map<String, Object> characterMethods;
 	static {
-		//characterMethods.put("java/lang/StringBuffer:append:(Ljava/lang/String;)Ljava/lang/StringBuffer;", Values.ZERO);
-		//characterMethods.put("java/lang/StringBuilder:append:(Ljava/lang/String;)Ljava/lang/StringBuilder;", Values.ZERO);
-		characterMethods.put("java/lang/String:indexOf:(Ljava/lang/String;)I", Values.ZERO);
-		characterMethods.put("java/lang/String:indexOf:(Ljava/lang/String;I)I", Values.ONE);
-		characterMethods.put("java/lang/String:lastIndexOf:(Ljava/lang/String;)I", Values.ZERO);
-		characterMethods.put("java/lang/String:lastIndexOf:(Ljava/lang/String;I)I", Values.ONE);
-		//characterMethods.put("java/lang/String:startsWith:(Ljava/lang/String;)Z", Values.ZERO);
-		characterMethods.put("java/io/PrintStream:print:(Ljava/lang/String;)V", Values.ZERO);
-		characterMethods.put("java/io/PrintStream:println:(Ljava/lang/String;)V", Values.ZERO);
-		characterMethods.put("java/io/StringWriter:write:(Ljava/lang/String;)V", Values.ZERO);
+	    Map<String, Object> methodsMap = new HashMap<String, Object>();
+	    //The values are where the parameter will be on the stack - For example, a value of 0 means the String literal to check
+	    // was the last parameter, and a stack offset of 2 means it was the 3rd to last. 
+	    methodsMap.put("java/lang/String:indexOf:(Ljava/lang/String;)I", Values.ZERO);
+	    methodsMap.put("java/lang/String:indexOf:(Ljava/lang/String;I)I", Values.ONE);
+	    methodsMap.put("java/lang/String:lastIndexOf:(Ljava/lang/String;)I", Values.ZERO);
+	    methodsMap.put("java/lang/String:lastIndexOf:(Ljava/lang/String;I)I", Values.ONE);
+	    methodsMap.put("java/io/PrintStream:print:(Ljava/lang/String;)V", Values.ZERO);
+	    methodsMap.put("java/io/PrintStream:println:(Ljava/lang/String;)V", Values.ZERO);
+	    methodsMap.put("java/io/StringWriter:write:(Ljava/lang/String;)V", Values.ZERO);
+	    methodsMap.put("java/lang/StringBuffer:append:(Ljava/lang/String;)Ljava/lang/StringBuffer;", Values.ZERO);
+	    methodsMap.put("java/lang/StringBuilder:append:(Ljava/lang/String;)Ljava/lang/StringBuilder;", Values.ZERO);
+	    
+	    // same thing as above, except now with two params
+	    methodsMap.put("java/lang/String:replace:(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;", new IntPair(0, 1));
+	    
+	    characterMethods = Collections.unmodifiableMap(methodsMap);
+	}
+	
+	private static class IntPair {
+	    public final int firstStringParam, secondStringParam;
+
+        public IntPair(int firstStringParam, int secondStringParam) {
+            this.firstStringParam = firstStringParam;
+            this.secondStringParam = secondStringParam;
+        }
 	}
 	
 	private final BugReporter bugReporter;
@@ -77,13 +94,9 @@ public class UseCharacterParameterizedMethod extends BytecodeScanningDetector
 	public void visitClassContext(final ClassContext context) {
 		try {
 			stack = new OpcodeStack();
-			if (context.getJavaClass().getMajor() >= Constants.MAJOR_1_5) {
-				characterMethods.put("java/lang/StringBuffer:append:(Ljava/lang/String;)Ljava/lang/StringBuffer;", Values.ZERO);
-			}
 			super.visitClassContext(context);
 		} finally {
 			stack = null;
-			characterMethods.remove("java/lang/StringBuffer:append:(Ljava/lang/String;)Ljava/lang/StringBuffer;");
 		}
 	}
 	
@@ -100,7 +113,7 @@ public class UseCharacterParameterizedMethod extends BytecodeScanningDetector
 	}
 	
 	/**
-	 * implement the visitor prescreen the method, and reset the stack
+	 * prescreens the method, and reset the stack
 	 * 
 	 * @param obj the context object for the currently parsed method
 	 */
@@ -123,23 +136,45 @@ public class UseCharacterParameterizedMethod extends BytecodeScanningDetector
 	        
 			if ((seen == INVOKEVIRTUAL) || (seen == INVOKEINTERFACE)) {
 				String key = getClassConstantOperand() + ':' + getNameConstantOperand() + ':' + getSigConstantOperand();
-				Integer parmPos =characterMethods.get(key);
-				if (parmPos != null) {
-					int stackPos = parmPos.intValue();
-					if (stack.getStackDepth() > stackPos) {
-						OpcodeStack.Item itm = stack.getStackItem(stackPos);
-						String con = (String)itm.getConstant();
-						if ((con != null) && (con.length() == 1)) {
-							bugReporter.reportBug(new BugInstance(this, BugType.UCPM_USE_CHARACTER_PARAMETERIZED_METHOD.name(), NORMAL_PRIORITY)
-									.addClass(this)
-									.addMethod(this)
-									.addSourceLine(this));
-						}
-					}
+				
+				Object posObject = characterMethods.get(key);
+				if (posObject instanceof Integer) {
+				    if (checkSingleParamMethod((Integer) posObject)) {
+				        reportBug();
+				    }
+				} else if (posObject instanceof IntPair) {
+				    if (checkDoubleParamMethod((IntPair) posObject)) {
+				        reportBug();
+				    }
 				}
 			}
 		} finally {
 			stack.sawOpcode(this, seen);
 		}
 	}
+
+    private void reportBug() {
+        bugReporter.reportBug(new BugInstance(this, BugType.UCPM_USE_CHARACTER_PARAMETERIZED_METHOD.name(), NORMAL_PRIORITY)
+        .addClass(this)
+        .addMethod(this)
+        .addSourceLine(this));
+    }
+
+    private boolean checkDoubleParamMethod(IntPair posObject) {
+        return checkSingleParamMethod(posObject.firstStringParam) && checkSingleParamMethod(posObject.secondStringParam);
+    }
+
+    private boolean checkSingleParamMethod(Integer paramPos) {
+        int stackPos = paramPos.intValue();
+        if (stack.getStackDepth() > stackPos) {
+            OpcodeStack.Item itm = stack.getStackItem(stackPos);
+            // casting to CharSequence is safe as FindBugs 3 (and fb-contrib 6) require Java 1.7 or later to run
+            // it's also needed with the addition of support for replace (which takes charSequences
+            CharSequence con = (CharSequence) itm.getConstant();     
+            if ((con != null) && (con.length() == 1)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
I meant to have this in yesterday's merge, but the branch was hiding on me.

I made the test cases more robust, fixed some bugs, added functionality [e.g. replace("a","b")] and made the collection of detectable things public so I could access it in fb-contrib-eclipse-quickfixes.
