### PR TITLE
Add BugsUrl and AllBugsUrl to messages.xml

### DIFF
--- a/etc/bugdescriptions.xsl
+++ b/etc/bugdescriptions.xsl
@@ -40,6 +40,11 @@
 			<xsl:for-each select="//BugPattern[starts-with(@type,$abbrev)]">
 				<xsl:sort select="."/>
 				<li>
+					<a>
+					<xsl:attribute name="name">
+						<xsl:value-of select="@type"/>
+					</xsl:attribute>
+					</a>
 					<div class="bugcode">
 						<xsl:value-of select="@type"/>
 					</div>

--- a/etc/findbugsplugin.xsd
+++ b/etc/findbugsplugin.xsd
@@ -1,12 +1,13 @@
+
 <?xml version="1.0"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-	
+
 	<xsd:simpleType name="ClassType">
 		<xsd:restriction base="xsd:string">
-			<xsd:pattern value="[A-Za-z_][A-Za-z0-9_]*(.[A-Za-z_][A-Za-z0-9_]*)*"/> 
+			<xsd:pattern value="[A-Za-z_][A-Za-z0-9_]*(.[A-Za-z_][A-Za-z0-9_]*)*"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-		
+
 	<xsd:simpleType name="SpeedType">
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="fast"/>
@@ -14,47 +15,98 @@
 			<xsd:enumeration value="slow"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="BugPatternListType">
 		<xsd:restriction base="xsd:string">
 			<xsd:pattern value="[A-Za-z0-9_]*(,[A-Za-z0-9_]*)*"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<xsd:simpleType name="IdentifierType">
 		<xsd:restriction base="xsd:string">
 			<xsd:pattern value="[A-Za-z0-9_]*"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-	
-	<xsd:simpleType name="CategoryType">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="CORRECTNESS"/>
-			<xsd:enumeration value="I18N"/>
-			<xsd:enumeration value="MALICIOUS_CODE"/>
-			<xsd:enumeration value="MT_CORRECTNESS"/>
-			<xsd:enumeration value="PERFORMANCE"/>
-			<xsd:enumeration value="BAD_PRACTICE"/>
-			<xsd:enumeration value="STYLE"/>		
-			<xsd:enumeration value="SECURITY"/>				
-		</xsd:restriction>
-	</xsd:simpleType>
+
+
+	<xsd:complexType name="CloudType">
+		<xsd:sequence>
+		<xsd:element name="Property" minOccurs="0" maxOccurs="unbounded" >
+			<xsd:complexType>
+				<xsd:simpleContent>
+					<xsd:extension base="xsd:string">
+						<xsd:attribute name="key" type="xsd:string" />
+					</xsd:extension>
+				</xsd:simpleContent>
+			</xsd:complexType>
+		</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="ClassType"/>
+		<xsd:attribute name="cloudClass" type="ClassType"/>
+		<xsd:attribute name="usernameClass" type="ClassType"/>
+		<xsd:attribute name="disabled" type="xsd:boolean" use="optional"/>
+		<xsd:attribute name="onlineStorage" type="xsd:boolean" use="optional"/>
+		<xsd:attribute name="hidden" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="PluginComponentType">
+		<xsd:sequence>
+			<xsd:element name="Property" minOccurs="0" maxOccurs="unbounded" >
+				<xsd:complexType>
+					<xsd:simpleContent>
+						<xsd:extension base="xsd:string">
+							<xsd:attribute name="key" type="xsd:string" />
+						</xsd:extension>
+					</xsd:simpleContent>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="ClassType"/>
+		<xsd:attribute name="componentKind" type="ClassType"/>
+		<xsd:attribute name="componentClass" type="ClassType"/>
+		<xsd:attribute name="disabled" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="FindBugsMainType">
+		<xsd:attribute name="class" type="ClassType"/>
+		<xsd:attribute name="cmd" type="xsd:string"/>
+		<xsd:attribute name="kind" type="xsd:string" use="optional"/>
+		<xsd:attribute name="analysis" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
 	
 	<xsd:complexType name="DetectorType">
 		<xsd:attribute name="class" type="ClassType"/>
-		<xsd:attribute name="speed" type="SpeedType"/>
+		<xsd:attribute name="speed" type="SpeedType" use="optional"/>
 		<xsd:attribute name="reports" type="BugPatternListType"/>
-		<xsd:attribute name="requirejre" type="xsd:string"/>
+		<xsd:attribute name="requirejre" type="xsd:string" use="optional"/>
 		<xsd:attribute name="disabled" type="xsd:boolean" use="optional"/>
 		<xsd:attribute name="hidden" type="xsd:boolean" use="optional"/>
 	</xsd:complexType>
-	
+
+	<xsd:complexType name="EngineRegistrarType">
+		<xsd:attribute name="class" type="ClassType"/>
+	</xsd:complexType>
+
 	<xsd:complexType name="BugPatternType">
 		<xsd:attribute name="abbrev" type="IdentifierType"/>
 		<xsd:attribute name="type" type="xsd:ID"/>
-		<xsd:attribute name="category" type="CategoryType"/>
+		<xsd:attribute name="category" type="IdentifierType"/>
 		<xsd:attribute name="experimental" type="xsd:boolean" use="optional"/>
+		<xsd:attribute name="cweid" type="xsd:positiveInteger" use="optional"/>
+		<xsd:attribute name="deprecated" type="xsd:boolean" use="optional"/>
 	</xsd:complexType>
+
+	<xsd:complexType name="BugCodeType">
+		<xsd:attribute name="abbrev" type="IdentifierType"/>
+		<xsd:attribute name="cweid" type="xsd:positiveInteger" use="optional"/>
+		<xsd:attribute name="hidden" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BugCategoryType">
+		<xsd:attribute name="category" type="IdentifierType"/>
+		<xsd:attribute name="hidden" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+	
 
 	<xsd:simpleType name="DetectorCategoryType">
 		<xsd:restriction base="xsd:string">
@@ -63,13 +115,18 @@
 			<xsd:enumeration value="interprocedural"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<xsd:complexType name="SingleDetectorSelectorType">
 		<xsd:attribute name="class" type="ClassType" use="required"/>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="DetectorCategorySelectorType">
 		<xsd:attribute name="name" type="DetectorCategoryType" use="required"/>
+		<xsd:attribute name="spanplugins" type="xsd:boolean" use="optional" default="false"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="DetectorSubtypesSelectorType">
+		<xsd:attribute name="super" type="ClassType" use="required"/>
 		<xsd:attribute name="spanplugins" type="xsd:boolean" use="optional" default="false"/>
 	</xsd:complexType>
 
@@ -78,14 +135,16 @@
 			<xsd:choice>
 				<xsd:element name="Earlier" type="SingleDetectorSelectorType"></xsd:element>
 				<xsd:element name="EarlierCategory" type="DetectorCategorySelectorType"></xsd:element>
+				<xsd:element name="EarlierSubtypes" type="DetectorSubtypesSelectorType"></xsd:element>
 			</xsd:choice>
 			<xsd:choice>
 				<xsd:element name="Later" type="SingleDetectorSelectorType"></xsd:element>
 				<xsd:element name="LaterCategory" type="DetectorCategorySelectorType"></xsd:element>
+				<xsd:element name="LaterSubtypes" type="DetectorSubtypesSelectorType"></xsd:element>
 			</xsd:choice>
 		</xsd:sequence>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="OrderingConstraintListType">
 		<xsd:sequence>
 			<xsd:choice minOccurs="0" maxOccurs="unbounded">
@@ -95,20 +154,46 @@
 		</xsd:sequence>
 	</xsd:complexType>
 	
+	<xsd:complexType name="GlobalOptionsType">
+		<xsd:sequence>
+			<xsd:element name="Property" minOccurs="0" maxOccurs="unbounded" >
+				<xsd:complexType>
+					<xsd:simpleContent>
+						<xsd:extension base="xsd:string">
+							<xsd:attribute name="key" type="xsd:string" />
+						</xsd:extension>
+					</xsd:simpleContent>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+
 	<xsd:complexType name="FindBugsPluginType" mixed="true">
 		<xsd:sequence>
+			<xsd:element name="GlobalOptions" type="GlobalOptionsType" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="Cloud" type="CloudType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="PluginComponent" type="PluginComponentType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="FindBugsMain" type="FindBugsMainType" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element
 				name="OrderingConstraints"
 				type="OrderingConstraintListType"
 				minOccurs="0"
 				maxOccurs="1"/>
-			<xsd:element name="Detector" type="DetectorType" minOccurs="1" maxOccurs="unbounded"/>
-			<xsd:element name="BugPattern" type="BugPatternType" minOccurs="1" maxOccurs="unbounded"/>
+		   <xsd:element name="Detector" type="DetectorType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="EngineRegistrar" type="EngineRegistrarType" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="BugCategory" type="BugCategoryType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="BugCode" type="BugCodeType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="BugPattern" type="BugPatternType" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute name="pluginid" type="xsd:string"/>
-		<xsd:attribute name="defaultenabled" type="xsd:boolean"/>
+		<xsd:attribute name="version" type="xsd:string"/>
+		<xsd:attribute name="cannotDisable" type="xsd:boolean" use="optional" />
+		
+		<xsd:attribute name="defaultenabled" type="xsd:boolean" use="optional" />
 		<xsd:attribute name="provider" type="xsd:string"/>
 		<xsd:attribute name="website" type="xsd:anyURI" use="optional"/>
+		<xsd:attribute name="update-url" type="xsd:anyURI" use="optional"/>
 	</xsd:complexType>
 
 	<xsd:element name="FindbugsPlugin" type="FindBugsPluginType"/>

--- a/etc/messagecollection.xsd
+++ b/etc/messagecollection.xsd
@@ -1,12 +1,13 @@
+
 <?xml version="1.0"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
 	<xsd:simpleType name="ClassType">
 		<xsd:restriction base="xsd:string">
-			<xsd:pattern value="[A-Za-z_][A-Za-z0-9_]*(.[A-Za-z_][A-Za-z0-9_]*)*"/> 
+			<xsd:pattern value="[A-Za-z_][A-Za-z0-9_]*(.[A-Za-z_][A-Za-z0-9_]*)*"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-		
+
 	<xsd:simpleType name="IdentifierType">
 		<xsd:restriction base="xsd:string">
 			<xsd:pattern value="[A-Za-z0-9_]*"/>
@@ -15,17 +16,52 @@
 
 	<xsd:complexType name="PluginType">
 		<xsd:sequence>
-			<xsd:element name="ShortDescription" type="xsd:string"/>
-			<xsd:element name="Details" type="xsd:string"/>
+			<xsd:element name="ShortDescription" type="xsd:string" />
+			<xsd:element name="Details" type="xsd:string" />
+			<xsd:element name="BugsUrl" type="xsd:string" maxOccurs="1" minOccurs="0"></xsd:element>
+			<xsd:element name="AllBugsUrl" type="xsd:string" maxOccurs="1" minOccurs="0"></xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
+
+	<xsd:complexType name="PluginComponentType">
+		<xsd:sequence>
+			<xsd:element name="Description" type="xsd:string"  minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="Details" type="xsd:string"  minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="ClassType"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="FindBugsMainType">
+		<xsd:sequence>
+			<xsd:element name="Description" type="xsd:string"  minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="cmd" type="xsd:string"/>
+		<xsd:attribute name="class" type="ClassType"/>
+	</xsd:complexType>
+	
+	<xsd:complexType name="CloudType">
+		<xsd:sequence>
+			<xsd:element name="Description" type="xsd:string"  minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="Details" type="xsd:string"  minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="ClassType"/>
+	</xsd:complexType>
+
 
 	<xsd:complexType name="DetectorType">
 		<xsd:sequence>
 			<xsd:element name="Details" type="xsd:string"/>
 		</xsd:sequence>
 		<xsd:attribute name="class" type="ClassType"/>
-		<xsd:attribute name="disabled" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="BugCategoryType">
+		<xsd:sequence>
+			<xsd:element name="Description" type="xsd:string"/>
+			<xsd:element name="Abbreviation" type="xsd:NMTOKEN"/> <!--typically a single capital letter-->
+			<xsd:element name="Details" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="category" type="IdentifierType"/>
 	</xsd:complexType>
 
 	<xsd:complexType name="BugPatternType">
@@ -35,8 +71,9 @@
 			<xsd:element name="Details" type="xsd:string"/>
 		</xsd:sequence>
 		<xsd:attribute name="type" type="IdentifierType"/>
+		<xsd:attribute name="deprecated" type="xsd:boolean" use="optional"/>
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="BugCodeType" mixed="true">
 		<xsd:attribute name="abbrev" type="xsd:ID"/>
 	</xsd:complexType>
@@ -44,6 +81,10 @@
 	<xsd:complexType name="MessageCollectionType" mixed="true">
 		<xsd:sequence>
 			<xsd:element name="Plugin" type="PluginType"/>
+			<xsd:element name="FindBugsMain" type="FindBugsMainType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="Cloud" type="CloudType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="PluginComponent" type="PluginComponentType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="BugCategory" type="BugCategoryType" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element name="Detector" type="DetectorType" minOccurs="1" maxOccurs="unbounded"/>
 			<xsd:element name="BugPattern" type="BugPatternType" minOccurs="1" maxOccurs="unbounded"/>
 			<xsd:element name="BugCode" type="BugCodeType" minOccurs="1" maxOccurs="unbounded"/>

--- a/etc/messages.xml
+++ b/etc/messages.xml
@@ -9,6 +9,8 @@
 			<p>This plugin contains FindBugs detectors from the fb-contrib project</p>
 			]]>
 		</Details>
+		<BugsUrl>http://fb-contrib.sourceforge.net/bugdescriptions.html</BugsUrl>
+		<AllBugsUrl>http://fb-contrib.sourceforge.net/bugdescriptions.html</AllBugsUrl>
 	</Plugin>
 
 	<!-- Detectors -->


### PR DESCRIPTION
Add support for `BugsUrl` and `AllBugsUrl` to messages.xml
Ref: http://sourceforge.net/p/findbugs/bugs/1342/

Add anchors to XSLT file.

Bonus: Update the xsd (in order to not break messages.xml)
https://findbugs.googlecode.com/git/findbugs/etc/messagecollection.xsd
https://findbugs.googlecode.com/git/findbugs/etc/findbugsplugin.xsd