### PR TITLE
Fix UTAO checks for double equality

### DIFF
--- a/samples/UTAO_Sample.java
+++ b/samples/UTAO_Sample.java
@@ -7,6 +7,9 @@ public class UTAO_Sample extends TestCase {
 
     public void testExactDoubles(double d1, double d2) {
         Assert.assertEquals(d1, d2);
+        Assert.assertEquals("Still bad", d1, d2);
+        Assert.assertEquals(0.1, d1, d2);	// Actually good
+        Assert.assertEquals("This one is ok", 0.1, d1, d2);	// Still good
     }
 
     public void testTrue(boolean b) {
@@ -67,7 +70,6 @@ public class UTAO_Sample extends TestCase {
     public void test3ArgNP(float foo, int boo) {
         Assert.assertEquals(1.0f, foo, 0.1);
         Assert.assertEquals(20, boo, 0);
-
     }
 }
 
@@ -109,6 +111,11 @@ class TestNG {
     @org.testng.annotations.Test
     public void testFalse(boolean b) {
         org.testng.Assert.assertEquals(b, false, "Wow this is bad");
+    }
+    
+    @org.testng.annotations.Test
+    public void testExactDoubles(double d1, double d2) {
+    	org.testng.Assert.assertEquals(d1, d2, "Don't ever do this!");
     }
     
     @org.testng.annotations.Test
@@ -163,8 +170,8 @@ class TestNG {
 
     @org.testng.annotations.Test
     public void test3ArgNP(float foo, int boo) {
-        Assert.assertEquals(foo, 1.0f, 0.1);
-        Assert.assertEquals(boo, 20, 0);
+    	org.testng.Assert.assertEquals(foo, 1.0f, 0.1);
+    	org.testng.Assert.assertEquals(boo, 20, 0);
     }
     
     @org.testng.annotations.Test(expectedExceptions=RuntimeException.class)

--- a/src/com/mebigfatguy/fbcontrib/detect/UnitTestAssertionOddities.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/UnitTestAssertionOddities.java
@@ -49,6 +49,7 @@ public class UnitTestAssertionOddities extends BytecodeScanningDetector {
     }
 
     private static final String BOOLEAN_TYPE_SIGNATURE = "Ljava/lang/Boolean;";
+    private static final String LJAVA_LANG_DOUBLE = "Ljava/lang/Double;";
     
     private static final String TESTCASE_CLASS = "junit.framework.TestCase";
     private static final String TEST_CLASS = "org.junit.Test";
@@ -210,13 +211,13 @@ public class UnitTestAssertionOddities extends BytecodeScanningDetector {
                                             .addClass(this).addMethod(this).addSourceLine(this));
                                     return;
                                 }
-                                if (argTypes[argTypes.length - 1].equals(Type.OBJECT) && argTypes[argTypes.length - 2].equals(Type.OBJECT)) {
-                                    if ("Ljava/lang/Double;".equals(item0.getSignature()) && "Ljava/lang/Double;".equals(expectedItem.getSignature())) {
-                                        bugReporter
-                                                .reportBug(new BugInstance(this, BugType.UTAO_JUNIT_ASSERTION_ODDITIES_INEXACT_DOUBLE.name(), NORMAL_PRIORITY)
-                                                        .addClass(this).addMethod(this).addSourceLine(this));
-                                        return;
-                                    }
+                                if (argTypes[argTypes.length - 1].equals(Type.DOUBLE) && argTypes[argTypes.length - 2].equals(Type.DOUBLE)) {
+                                	if (argTypes.length < 3 || !argTypes[argTypes.length - 3].equals(Type.DOUBLE)) {
+	                                    bugReporter
+	                                            .reportBug(new BugInstance(this, BugType.UTAO_JUNIT_ASSERTION_ODDITIES_INEXACT_DOUBLE.name(), NORMAL_PRIORITY)
+	                                                    .addClass(this).addMethod(this).addSourceLine(this));
+	                                    return;
+                                	}
                                 }
                             }
                         }
@@ -285,8 +286,8 @@ public class UnitTestAssertionOddities extends BytecodeScanningDetector {
                                         .addClass(this).addMethod(this).addSourceLine(this));
                                 return;
                             }
-                            if (argTypes[argTypes.length - 1].equals(Type.OBJECT) && argTypes[argTypes.length - 2].equals(Type.OBJECT)) {
-                                if ("Ljava/lang/Double;".equals(actualItem.getSignature()) && "Ljava/lang/Double;".equals(expectedItem.getSignature())) {
+                            if (argTypes[0].equals(Type.OBJECT) && argTypes[1].equals(Type.OBJECT)) {
+                                if (LJAVA_LANG_DOUBLE.equals(actualItem.getSignature()) && LJAVA_LANG_DOUBLE.equals(expectedItem.getSignature())) {
                                     bugReporter.reportBug(new BugInstance(this, BugType.UTAO_TESTNG_ASSERTION_ODDITIES_INEXACT_DOUBLE.name(), NORMAL_PRIORITY)
                                             .addClass(this).addMethod(this).addSourceLine(this));
                                     return;


### PR DESCRIPTION
Again, for TestNG indexes for expected / actual parameters are constant regardles of parameter count.
For JUnit we need to check against `double` and not `Object`.

Notice that using boxed `Double` will use `Assert.assertEquals(Object, Object)`. This may not be what is intended, but due to the hadling of `null` values, suggesting to use `assertEquals(double, double, double)` may not be the safest option. Since that scenario was not included in samples, I asssumed it was intentionally left out.