### PR TITLE
Update messages for incorrect internal class use

### DIFF
--- a/etc/messages.xml
+++ b/etc/messages.xml
@@ -911,7 +911,7 @@
 			should not be counted on.</p>
 			Packages that shouldn't be used are:
 			<ul>
-				<li>com.sun.xxx</li>
+				<li>sun.xxx</li>
 				<li>org.apache.xerces.xxx</li>
 				<li>org.apache.xalan.xxx</li>
 			</ul>
@@ -3852,7 +3852,7 @@
 			to change or removal. You should not be using these classes.</p>
 			Packages that shouldn't be used are:
 			<ul>
-				<li>com.sun.xxx</li>
+				<li>sun.xxx</li>
 				<li>org.apache.xerces.xxx</li>
 				<li>org.apache.xalan.xxx</li>
 			</ul>


### PR DESCRIPTION
The detector IncorrectInternalClassUse was changed to check for "sun.*" packages instead for "com.sun.*" packages but the messages for detector and bug pattern were not updated.

Thanks!
