### PR TITLE
oops fix slashes vs dots when comparing class names, Github #86

### DIFF
--- a/src/com/mebigfatguy/fbcontrib/detect/ClassEnvy.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/ClassEnvy.java
@@ -319,6 +319,7 @@ public class ClassEnvy extends BytecodeScanningDetector {
      *
      * @return whether or not the class is general purpose
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_RETURN_FALSE", justification = "No other simple way to determine whether class exists")
     private boolean generalPurpose(final String className) {
 
         if (className.startsWith("java.") || className.startsWith("javax.")) {

--- a/src/com/mebigfatguy/fbcontrib/detect/CollectionNamingConfusion.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/CollectionNamingConfusion.java
@@ -1,17 +1,17 @@
 /*
  * fb-contrib - Auxiliary detectors for Java programs
  * Copyright (C) 2005-2016 Dave Brosius
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -99,13 +99,14 @@ public class CollectionNamingConfusion extends PreorderVisitor implements Detect
     /**
      * looks for a name that mentions a collection type but the wrong type for
      * the variable
-     * 
+     *
      * @param name
      *            the variable name
      * @param signature
      *            the variable signature
      * @return whether the name doesn't match the type
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_RETURN_FALSE", justification = "No other simple way to determine whether class exists")
     private boolean checkConfusedName(String name, String signature) {
         try {
             name = name.toLowerCase();

--- a/src/com/mebigfatguy/fbcontrib/detect/LoggerOddities.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/LoggerOddities.java
@@ -360,9 +360,6 @@ public class LoggerOddities extends BytecodeScanningDetector {
                 if (stack.getStackDepth() > 0) {
                     OpcodeStack.Item item = stack.getStackItem(0);
                     loggingClassName = (String) item.getConstant();
-                    if (loggingClassName != null) {
-                        loggingClassName = loggingClassName.replace('.', '/');
-                    }
                     loggingPriority = LOW_PRIORITY;
                 }
             }
@@ -382,22 +379,17 @@ public class LoggerOddities extends BytecodeScanningDetector {
 
                     if (loggingClassName != null) {
                         // first look at the constant passed in
-                        loggingClassName = loggingClassName.replace('.', '/');
                         loggingPriority = LOW_PRIORITY;
                     } else if (userValue instanceof String) {
                         // try the user value, which may have been set by a call
                         // to Foo.class.getName()
                         loggingClassName = (String) userValue;
-                        loggingClassName = loggingClassName.replace('.', '/');
                     }
                 }
             } else if ("(Ljava/lang/String;Lorg/apache/log4j/spi/LoggerFactory;)Lorg/apache/log4j/Logger;".equals(signature)) {
                 if (stack.getStackDepth() > 1) {
                     OpcodeStack.Item item = stack.getStackItem(1);
                     loggingClassName = (String) item.getConstant();
-                    if (loggingClassName != null) {
-                        loggingClassName = loggingClassName.replace('.', '/');
-                    }
                     loggingPriority = LOW_PRIORITY;
                 }
             }
@@ -413,15 +405,13 @@ public class LoggerOddities extends BytecodeScanningDetector {
                 if (stack.getStackDepth() > 0) {
                     OpcodeStack.Item item = stack.getStackItem(0);
                     loggingClassName = (String) item.getConstant();
-                    if (loggingClassName != null) {
-                        loggingClassName = loggingClassName.replace('.', '/');
-                    }
                     loggingPriority = LOW_PRIORITY;
                 }
             }
         }
 
         if (loggingClassName != null) {
+            loggingClassName = loggingClassName.replace('/', '.');
             if (stack.getStackDepth() > 0) {
                 if (!loggingClassName.equals(SignatureUtils.getNonAnonymousPortion(nameOfThisClass))) {
                     bugReporter.reportBug(new BugInstance(this, BugType.LO_SUSPECT_LOG_CLASS.name(), loggingPriority).addClass(this).addMethod(this)

--- a/src/com/mebigfatguy/fbcontrib/detect/StringifiedTypes.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/StringifiedTypes.java
@@ -152,14 +152,12 @@ public class StringifiedTypes extends BytecodeScanningDetector {
                                     }
                                 }
                             }
-                        } else if ("setLength".equals(methodName)) {
-                            if (stackDepth > 1) {
-                                OpcodeStack.Item item = stack.getStackItem(1);
-                                item.setUserValue(null);
-                                int reg = item.getRegisterNumber();
-                                if (reg >= 0) {
-                                    toStringStringBuilders.clear(reg);
-                                }
+                        } else if (stackDepth > 1 && "setLength".equals(methodName)) {
+                            OpcodeStack.Item item = stack.getStackItem(1);
+                            item.setUserValue(null);
+                            int reg = item.getRegisterNumber();
+                            if (reg >= 0) {
+                                toStringStringBuilders.clear(reg);
                             }
                         }
                     } else if ("java/lang/String".equals(clsName)) {


### PR DESCRIPTION
Old mechanism used slashes, new one uses dots.

Also, do the replacement in a single location.