### PR TITLE
Integrate Travis CI without FindBugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dfindbugs.skip=true -B -V
+jdk:
+    - openjdk7
+    - oraclejdk7
+    - oraclejdk8
+cache:
+    directories:
+        - $HOME/.m2


### PR DESCRIPTION
Configure a basic Travis integration to build fb-contrib on Java 7 and 8 using Maven.

`mvn install` fails with a single `FCBL` error in `CollectStatistics`, resolution tracked in #124. This breaks the build so override the default `install` directive with a flag to disable FindBugs entirely. When resolved, the `install` directive can be removed entirely.

This makes no provisions for Ant. Travis CI does have Ant, and falls back to it if neither Maven nor Gradle are configured, so it would probably be possible to develop a shell wrapper that builds both versions.