### PR TITLE
Ignore PRMC for java.util.stream.Collectors

### DIFF
--- a/src/com/mebigfatguy/fbcontrib/detect/PossiblyRedundantMethodCalls.java
+++ b/src/com/mebigfatguy/fbcontrib/detect/PossiblyRedundantMethodCalls.java
@@ -124,6 +124,7 @@ public class PossiblyRedundantMethodCalls extends BytecodeScanningDetector {
         riskyClassNames.add("java/io/DataInputStream");
         riskyClassNames.add("java/io/ObjectInputStream");
         riskyClassNames.add("java/util/Calendar");
+        riskyClassNames.add("java/util/stream/Collectors");
         riskyClassNames.add("com/google/common/collect/Lists");
         riskyClassNames.add("com/google/common/collect/Sets");
         riskyClassNames.add("com/google/common/collect/Maps");


### PR DESCRIPTION
Java 8's `java.util.stream.Collectors` provides static helper factories for use with
`Stream::collect`, such as `Collectors::toList`. Multiple invocations of
such a factory within the same method can trigger PRMC.

Although technically collectors can be reused, the API was mainly designed for sink arguments and reuse will rarely make sense. Ignore the class.

I've verified this change with a separate FindBugs installation. Given the minimum Java version of 7 I don't see a way to provide an automated test.