### PR TITLE
provide 'build' method so SignatureBuilder clients don't have to rely…

### DIFF
--- a/src/com/mebigfatguy/fbcontrib/utils/SignatureBuilder.java
+++ b/src/com/mebigfatguy/fbcontrib/utils/SignatureBuilder.java
@@ -105,9 +105,13 @@ public class SignatureBuilder {
         return this;
     }
 
+    public String build() {
+        return methodName + '(' + join(paramTypes) + ')' + returnType;
+    }
+
     @Override
     public String toString() {
-        return methodName + '(' + join(paramTypes) + ')' + returnType;
+        return build();
     }
 
     private String join(List<String> strings) {


### PR DESCRIPTION
… on toString