### PR TITLE
USFW_Sample: don't use @Scope "scopeName" attribute

### DIFF
--- a/src/samples/java/USFW_Sample.java
+++ b/src/samples/java/USFW_Sample.java
@@ -26,7 +26,7 @@ class USFW1_Sample {
 }
 
 @Repository
-@Scope(scopeName = "singleton")
+@Scope("singleton")
 class USFW2_Sample {
 
     private String s;


### PR DESCRIPTION
See:

  http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/Scope.html#scopeName--

"scopeName" was added in 4.2 and is an alias for "value" (i.e. the default attribute).

Make USFW_Sample compatible with older versions of Spring by not using "scopeName". (The other two uses of @Scope in USFW_Sample don't use "scopeName".)