### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency><scope>test</scope><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>19.0</version></dependency>
         <dependency><scope>test</scope><groupId>commons-codec</groupId><artifactId>commons-codec</artifactId><version>1.10</version></dependency>
         <dependency><scope>test</scope><groupId>commons-io</groupId><artifactId>commons-io</artifactId><version>2.4</version></dependency>
-        <dependency><scope>test</scope><groupId>commons-collections</groupId><artifactId>commons-collections</artifactId><version>3.2.1</version></dependency>
+        <dependency><scope>test</scope><groupId>commons-collections</groupId><artifactId>commons-collections</artifactId><version>3.2.2</version></dependency>
         <dependency><scope>test</scope><groupId>javax.persistence</groupId><artifactId>persistence-api</artifactId><version>1.0.2</version></dependency>
         <dependency><scope>test</scope><groupId>javax.servlet</groupId><artifactId>javax.servlet-api</artifactId><version>3.1.0</version></dependency>
         <dependency><scope>test</scope><groupId>javax.servlet.jsp</groupId><artifactId>javax.servlet.jsp-api</artifactId><version>2.3.1</version></dependency>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/