### PR TITLE
Fix wrong executions closing tag in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The group ID for fb-contrib is com.mebigfatguy.fb-contrib, and the artifact ID i
                 <goal>check</goal>
             </goals>
         </execution>
-    </execution>
+    </executions>
 </plugin>
 ~~~~
 


### PR DESCRIPTION
Hi,

I noticed when copy-pasting the POM snippet that the `executions` closing tag wasn't correct.

Cheers,
Pablo