### PR TITLE
[pom] Exclude unnecessary libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
             <artifactId>findbugs</artifactId>
             <version>3.0.1</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -277,6 +283,12 @@
             <artifactId>jersey-media-multipart</artifactId>
             <version>2.25.1</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>osgi-resource-locator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>


### PR DESCRIPTION
While only in test/provided, neither of these were needed.

- xml-apis is part of java since java 6.
- osgi locator only needed for osgi projects
