### PR TITLE
[pom] Switch findbugs to spotbugs 3.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,9 +340,9 @@
                     <version>1.9.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>2.5.5</version>
+                    <groupId>com.github.hazendaz.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>3.0.6</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -506,9 +506,8 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
+                <groupId>com.github.hazendaz.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
                 <dependencies>
                     <dependency>
                         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Findbugs has been replaced for now as spotbugs.  It's drop in place with additional checks.  This maven plugin is a continuation of the findbugs maven plugin and will exist while attempts to get code back to original (basically same thing spot bugs team is doing).  If things change, switch back will occur but for now this is good and has been tested by a number of other projects with most noteably checkstyles starting to use it.