### PR TITLE
Fix inverted check for custom annotations system property

### DIFF
--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/AnnotationIssues.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/AnnotationIssues.java
@@ -65,7 +65,7 @@ public class AnnotationIssues extends BytecodeScanningDetector {
         NULLABLE_ANNOTATIONS.add("Landroid/support/annotations/Nullable");
 
         String userAnnotations = System.getProperty(USER_NULLABLE_ANNOTATIONS);
-        if ((userAnnotations != null) && userAnnotations.isEmpty()) {
+        if ((userAnnotations != null) && !userAnnotations.isEmpty()) {
             String[] annotations = userAnnotations.split(Values.WHITESPACE_COMMA_SPLIT);
             for (String annotation : annotations) {
                 NULLABLE_ANNOTATIONS.add("L" + annotation.replace('.', '/') + ";");


### PR DESCRIPTION
The custom property doesn't work in fb-contrib 7.2.1.