### PR TITLE
update PMD and fix its findings

### DIFF
--- a/etc/pmd-rules.xml
+++ b/etc/pmd-rules.xml
@@ -17,6 +17,8 @@
     <exclude name="SwitchStmtsShouldHaveDefault"/>
     <!-- switching on strings is quite efficient -->
     <exclude name="TooFewBranchesForASwitchStatement"/>
+    <!-- data classes aren't evil -->
+    <exclude name="DataClass"/>
     <!-- would take serious refactoring in some cases -->
     <exclude name="GodClass"/>
     <!-- we already check this ourselves -->

--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.5</version>
+                    <version>3.9.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -419,12 +419,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>5.5.1</version>
+                        <version>6.4.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>5.5.1</version>
+                        <version>6.4.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/java/com/mebigfatguy/fbcontrib/collect/CollectStatistics.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/collect/CollectStatistics.java
@@ -268,8 +268,8 @@ public class CollectStatistics extends BytecodeScanningDetector implements NonRe
      * represents a method that is called, and whether it is in the super class
      */
     static class CalledMethod {
-        private QMethod callee;
-        private boolean isSuper;
+        final QMethod callee;
+        final boolean isSuper;
 
         public CalledMethod(QMethod c, boolean s) {
             callee = c;

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/BloatedAssignmentScope.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/BloatedAssignmentScope.java
@@ -97,7 +97,7 @@ public class BloatedAssignmentScope extends BytecodeScanningDetector {
 
     BugReporter bugReporter;
     private OpcodeStack stack;
-    private BitSet ignoreRegs;
+    BitSet ignoreRegs;
     private ScopeBlock rootScopeBlock;
     private BitSet tryBlocks;
     private BitSet catchHandlers;
@@ -632,8 +632,9 @@ public class BloatedAssignmentScope extends BytecodeScanningDetector {
             return null;
         }
 
-        if (sb.children != null) {
-            for (ScopeBlock child : sb.children) {
+        List<ScopeBlock> children = sb.getChildren();
+        if (children != null) {
+            for (ScopeBlock child : children) {
                 ScopeBlock foundSb = findScopeBlock(child, pc);
                 if (foundSb != null) {
                     return foundSb;
@@ -657,12 +658,14 @@ public class BloatedAssignmentScope extends BytecodeScanningDetector {
      */
     private ScopeBlock findScopeBlockWithTarget(ScopeBlock sb, int start, int target) {
         ScopeBlock parentBlock = null;
-        if ((sb.startLocation < start) && (sb.finishLocation >= start) && ((sb.finishLocation <= target) || (sb.isGoto() && !sb.isLoop()))) {
+        int finishLocation = sb.getFinish();
+        if ((sb.getStart() < start) && (finishLocation >= start) && ((finishLocation <= target) || (sb.isGoto() && !sb.isLoop()))) {
             parentBlock = sb;
         }
 
-        if (sb.children != null) {
-            for (ScopeBlock child : sb.children) {
+        List<ScopeBlock> children = sb.getChildren();
+        if (children != null) {
+            for (ScopeBlock child : children) {
                 ScopeBlock targetBlock = findScopeBlockWithTarget(child, start, target);
                 if (targetBlock != null) {
                     return targetBlock;

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/FinalParameters.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/FinalParameters.java
@@ -136,7 +136,7 @@ public class FinalParameters extends BytecodeScanningDetector {
                     while ((line = sourceReader.readLine()) != null) {
                         lines.add(line);
                     }
-                    sourceLines = lines.toArray(new String[lines.size()]);
+                    sourceLines = lines.toArray(new String[0]);
                 }
             }
         } catch (IOException ioe) {

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/FunctionalInterfaceIssues.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/FunctionalInterfaceIssues.java
@@ -245,7 +245,7 @@ public class FunctionalInterfaceIssues extends BytecodeScanningDetector {
 
                             int lastOp = getPrevOpcode(1);
                             FIInfo fii = new FIInfo(getMethod(), SourceLineAnnotation.fromVisitedInstruction(this),
-                                    OpcodeUtils.isALoad(lastOp) || (lastOp == Const.GETFIELD) || (lastOp == Const.GETSTATIC));
+                                    (lastOp == Const.GETFIELD) || (lastOp == Const.GETSTATIC) || OpcodeUtils.isALoad(lastOp));
                             fiis.add(fii);
                         }
                     break;

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/InvalidConstantArgument.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/InvalidConstantArgument.java
@@ -187,8 +187,8 @@ public class InvalidConstantArgument extends BytecodeScanningDetector {
      * what offset from the start or end of the method the parm is
      */
     static class ParameterInfo<T extends Comparable<T>> {
-        private int parameterOffset;
-        private boolean fromStart;
+        final int parameterOffset;
+        final boolean fromStart;
         private Set<T> validValues;
         private Range<T> range;
 

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/LiteralStringComparison.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/LiteralStringComparison.java
@@ -193,7 +193,7 @@ public class LiteralStringComparison extends BytecodeScanningDetector {
             if (!lookupSwitches.isEmpty()) {
                 int innerMostSwitch = lookupSwitches.size() - 1;
                 LookupDetails details = lookupSwitches.get(innerMostSwitch);
-                if (details.switchTargets.get(getPC()) && (stack.getStackDepth() > 0)) {
+                if (details.getSwitchTargets().get(getPC()) && (stack.getStackDepth() > 0)) {
                     OpcodeStack.Item item = stack.getStackItem(0);
                     item.setUserValue(details.getStringReference());
                 }

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/LostExceptionStackTrace.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/LostExceptionStackTrace.java
@@ -166,7 +166,7 @@ public class LostExceptionStackTrace extends BytecodeScanningDetector {
                 filteredEx.add(ce);
             }
         }
-        return filteredEx.toArray(new CodeException[filteredEx.size()]);
+        return filteredEx.toArray(new CodeException[0]);
     }
 
     /**

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/StackedTryBlocks.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/StackedTryBlocks.java
@@ -287,10 +287,10 @@ public class StackedTryBlocks extends BytecodeScanningDetector {
         if (!transitionPoints.isEmpty()) {
             int transitionPoint = transitionPoints.nextSetBit(0);
             while (transitionPoint >= 0) {
-                if (transitionPoint < firstBlock.handlerPC) {
+                if (transitionPoint < firstBlock.getHandlerPC()) {
                     transitionPoints.clear(transitionPoint);
                 } else {
-                    return transitionPoint < secondBlock.handlerPC;
+                    return transitionPoint < secondBlock.getHandlerPC();
                 }
                 transitionPoint = transitionPoints.nextSetBit(transitionPoint + 1);
             }
@@ -386,6 +386,10 @@ public class StackedTryBlocks extends BytecodeScanningDetector {
 
         int getStartPC() {
             return startPC;
+        }
+
+        int getHandlerPC() {
+            return handlerPC;
         }
 
         int getEndHandlerPC() {

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/SuspiciousGetterSetterUse.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/SuspiciousGetterSetterUse.java
@@ -35,9 +35,9 @@ import edu.umd.cs.findbugs.BytecodeScanningDetector;
  */
 public class SuspiciousGetterSetterUse extends BytecodeScanningDetector {
 
-    private static enum State {
+    private enum State {
         SEEN_NOTHING, SEEN_ALOAD, SEEN_GETFIELD, SEEN_DUAL_LOADS, SEEN_INVOKEVIRTUAL
-    };
+    }
 
     private final BugReporter bugReporter;
     private State state;

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/SuspiciousLoopSearch.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/SuspiciousLoopSearch.java
@@ -289,7 +289,7 @@ public class SuspiciousLoopSearch extends BytecodeScanningDetector {
     static class IfBlock {
         int start;
         int end;
-        private Map<Integer, Integer> storeRegs;
+        final Map<Integer, Integer> storeRegs;
 
         public IfBlock(int start, int end) {
             this.start = start;

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/UnboundMethodTemplateParameter.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/UnboundMethodTemplateParameter.java
@@ -140,7 +140,7 @@ public class UnboundMethodTemplateParameter extends PreorderVisitor implements D
         while (m.find()) {
             templates.add(new TemplateItem(m.group(1), m.group(2)));
         }
-        ts.templateParameters = templates.toArray(new TemplateItem[templates.size()]);
+        ts.templateParameters = templates.toArray(new TemplateItem[0]);
 
         return ts;
     }

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/UseAddAll.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/UseAddAll.java
@@ -105,14 +105,15 @@ public class UseAddAll extends AbstractCollectionScanningDetector {
             Iterator<LoopInfo> it = loops.values().iterator();
             while (it.hasNext()) {
                 LoopInfo loop = it.next();
-                if ((loop.getEndPC() - 3) <= pc) {
-                    int loopPC = loop.getAddPC();
+                int endPC = loop.getEndPC();
+                int loopPC = loop.getAddPC();
+                if ((endPC - 3) <= pc) {
                     if (loopPC > 0) {
                         bugReporter.reportBug(new BugInstance(this, BugType.UAA_USE_ADD_ALL.name(), NORMAL_PRIORITY).addClass(this).addMethod(this)
                                 .addSourceLine(this, loopPC));
                     }
                     it.remove();
-                } else if ((loop.getEndPC() > pc) && (loop.addPC < (pc - 5)) && (loop.addPC > 0)) {
+                } else if ((endPC > pc) && (loopPC < (pc - 5)) && (loopPC > 0)) {
                     it.remove();
                 }
             }


### PR DESCRIPTION
- put literal strings first in comparisons
- no need to specify that enums are static
- don't directly access private fields of member classes since that causes method generation
- define fields at the top of the class
- use zero-size arrays with toArray since they're more efficient on modern JVMs (no need to initialise them with zeros)
- put simple equality checks before method calls in conditionals