### PR TITLE
corrected the android support annotation package name

### DIFF
--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/AnnotationIssues.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/AnnotationIssues.java
@@ -93,7 +93,7 @@ public class AnnotationIssues extends BytecodeScanningDetector {
         NULLABLE_ANNOTATIONS.add("Lcom/sun/istack/Nullable;");
         NULLABLE_ANNOTATIONS.add("Ledu/umd/cs/findbugs/annotations/Nullable;");
         NULLABLE_ANNOTATIONS.add("Lorg/springframework/lang/Nullable;");
-        NULLABLE_ANNOTATIONS.add("Landroid/support/annotations/Nullable");
+        NULLABLE_ANNOTATIONS.add("Landroid/support/annotation/Nullable");
 
         String userAnnotations = System.getProperty(USER_NULLABLE_ANNOTATIONS);
         if ((userAnnotations != null) && !userAnnotations.isEmpty()) {


### PR DESCRIPTION
Issue created : https://github.com/mebigfatguy/fb-contrib/issues/299

Ref: https://developer.android.com/studio/write/annotations

Android supports a variety of annotations through the Annotations Support Library. You can access the library through the `android.support.annotation` package.