### PR TITLE
Fail build if Javadoc generation fails

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -260,7 +260,7 @@
 	</target>
 
 	<target name="javadoc" depends="-init" description="build the javadoc for the project">
-		<javadoc packagenames="com.mebigfatguy.*" sourcepath="${src.dir}" classpathref="fb-contrib.classpath" destdir="${javadoc.dir}" windowtitle="fb-contrib api" access="private">
+		<javadoc packagenames="com.mebigfatguy.*" sourcepath="${src.dir}" classpathref="fb-contrib.classpath" destdir="${javadoc.dir}" windowtitle="fb-contrib api" access="private" failonerror="true">
 			<doctitle><![CDATA[<h1>fb-contrib javadoc</h1>]]></doctitle>
 			<bottom><![CDATA[<i>Copyright &#169; 2005-2019 MeBigFatGuy.com. All Rights Reserved.</i>]]></bottom>
 		</javadoc>


### PR DESCRIPTION
There are currently no errors in the fb-contrib Javadoc, so `failonerror` can be set to `true` when generating Javadoc. Adding this option will help to prevent errors being introduced in the future.