### PR TITLE
Correctly compare non-object parameters in isConstrainedByInterface

### DIFF
--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/OverlyPermissiveMethod.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/OverlyPermissiveMethod.java
@@ -351,7 +351,7 @@ public class OverlyPermissiveMethod extends BytecodeScanningDetector {
                             for (int i = 0; i < infTypes.size(); i++) {
                                 String infParmType = infTypes.get(i);
                                 String fqParmType = fqTypes.get(i);
-                                if (infParmType.equals(fqParmType)) {
+                                if (!infParmType.equals(fqParmType)) {
                                     if (infParmType.charAt(0) != 'L' || fqParmType.charAt(0) != 'L') {
                                         matches = false;
                                         break;


### PR DESCRIPTION
I took a stab at making a pull request, thanks again!  Related to #437.