### PR TITLE
Added FII_AVOID_CONTAINS_ON_COLLECTED_STREAM missing category

### DIFF
--- a/etc/findbugs.xml
+++ b/etc/findbugs.xml
@@ -643,7 +643,7 @@
 	<BugPattern abbrev="LUI" type="LUI_USE_COLLECTION_ADD" category="CORRECTNESS" />
 	<BugPattern abbrev="LUI" type="LUI_USE_GET0" category="CORRECTNESS" />
 	<BugPattern abbrev="FII" type="FII_USE_METHOD_REFERENCE" category="CORRECTNESS" />
-	<BugPattern abbrev="FII" type="FII_AVOID_CONTAINS_ON_COLLECTED_STREAM"/>
+	<BugPattern abbrev="FII" type="FII_AVOID_CONTAINS_ON_COLLECTED_STREAM" category="CORRECTNESS" />
 	<BugPattern abbrev="FII" type="FII_USE_ANY_MATCH" category="CORRECTNESS"/>
 	<BugPattern abbrev="FII" type="FII_USE_FIND_FIRST" category="CORRECTNESS"/>
 	<BugPattern abbrev="FII" type="FII_COMBINE_FILTERS" category="CORRECTNESS"/>


### PR DESCRIPTION
`FII_AVOID_CONTAINS_ON_COLLECTED_STREAM` seems to be missing a category, this is causing a problem when converting the bug patterns into SonarQube rules.
I think this should be the same category as the other FII bug patterns