### PR TITLE
remove aj.org.objectweb.asm dependency from UnnecessaryStoreBeforeReturn

### DIFF
--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/UnnecessaryStoreBeforeReturn.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/UnnecessaryStoreBeforeReturn.java
@@ -32,7 +32,6 @@ import com.mebigfatguy.fbcontrib.utils.SignatureUtils;
 import com.mebigfatguy.fbcontrib.utils.TernaryPatcher;
 import com.mebigfatguy.fbcontrib.utils.Values;
 
-import aj.org.objectweb.asm.Opcodes;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
@@ -187,7 +186,7 @@ public class UnnecessaryStoreBeforeReturn extends BytecodeScanningDetector {
                     if ((reg == null) || (reg.intValue() != storeReg)) {
                         state = State.SEEN_STORE;
                     }
-                } else if (seen == Opcodes.CHECKCAST) {
+                } else if (seen == Const.CHECKCAST) {
                 	state = State.SEEN_CHECKCAST;
                 }
                 break;


### PR DESCRIPTION
It looks like the `CHECKCAST` opcode was referenced from `aj.org.objectweb.asm.Opcodes` instead of the already used `org.apache.bcel.Const` class.