### PR TITLE
fix `B` signature is for `byte`

### DIFF
--- a/src/main/java/com/mebigfatguy/fbcontrib/utils/SignatureUtils.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/utils/SignatureUtils.java
@@ -58,7 +58,7 @@ public final class SignatureUtils {
 
     private static final Map<String, String> PRIMITIVE_NAME_TO_SIG = new HashMap<>();
     static {
-        PRIMITIVE_NAME_TO_SIG.put("boolean", "B");
+        PRIMITIVE_NAME_TO_SIG.put("byte", "B");
         PRIMITIVE_NAME_TO_SIG.put("short", "S");
         PRIMITIVE_NAME_TO_SIG.put("int", "I");
         PRIMITIVE_NAME_TO_SIG.put("long", "J");


### PR DESCRIPTION
Fixing the signature in `SignatureUtils` class. The `B` signature is for `byte`, not for `boolean`. See https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/types.html#type_signatures