### PR TITLE
add build gha with maven

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: Java CI
+
+on: [workflow_dispatch, push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [8, 11, 17, 21, 22-ea]
+        distribution: ['temurin']
+      fail-fast: false
+      max-parallel: 4
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }} ${{ matrix.distribution }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: ${{ matrix.distribution }}
+      - name: Test with Maven
+        run: ./mvnw test -B -V --no-transfer-progress -D"license.skip=true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,4 +22,4 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
       - name: Test with Maven
-        run: ./mvnw test -B -V --no-transfer-progress -D"license.skip=true"
+        run: ./mvnw test -B -V --no-transfer-progress -D"license.skip=true" -D"cpd.skip=true" -D"spotbugs.skip=true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [8, 11, 17, 21, 22-ea]
+        java: [11, 17, 21, 23]
         distribution: ['temurin']
       fail-fast: false
       max-parallel: 4
@@ -22,4 +22,4 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
       - name: Test with Maven
-        run: ./mvnw test -B -V --no-transfer-progress -D"license.skip=true" -D"cpd.skip=true" -D"spotbugs.skip=true"
+        run: ./mvnw clean install -B -V --no-transfer-progress -D"license.skip=true" -D"cpd.skip=true" -D"spotbugs.skip=true" -D"pmd.skip=true"

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+
+  <servers>
+    <!-- Used for sonatype snapshots and releases -->
+    <server>
+      <id>ossrh</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+
+    <!-- Used for gh-pages deployments -->
+    <server>
+      <id>gh-pages</id>
+      <username>git</username>
+      <password>${env.CI_SITE_PASSWORD}</password>
+    </server>
+  </servers>
+
+</settings>


### PR DESCRIPTION
It looks like https://github.com/mebigfatguy/fb-contrib/pull/458 was closed, but I think it contains some really useful changes.
A part of it - fixing the maven build - is included in #478 (already merged).
This PR adds the GitHub Action running the build with maven. IMO this is really useful, because it shows automatically if the maven build is broken. Currently the cpd, spotbugs and pmd analysises are skipped, because there are some issues in the code reported by these. Otherwise the maven build is successful.

Thank you for your work with this, @hazendaz !
Co-authored-by: @hazendaz 