### PR TITLE
update pmd mvn plugin version and rulesets

### DIFF
--- a/etc/pmd-rules.xml
+++ b/etc/pmd-rules.xml
@@ -2,35 +2,28 @@
 <ruleset name="Custom ruleset"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>
   Selected PMD rules for fb-contrib
   </description>
-  <rule ref="rulesets/java/basic.xml">
-    <!-- these are used for readability -->
-    <exclude name="CollapsibleIfStatements"/>
-  </rule>
-  <rule ref="rulesets/java/design.xml">
+  <rule ref="category/java/design.xml">
     <!-- not really necessary -->
     <exclude name="ImmutableField"/>
-    <!-- not always appropriate -->
-    <exclude name="SwitchStmtsShouldHaveDefault"/>
-    <!-- switching on strings is quite efficient -->
-    <exclude name="TooFewBranchesForASwitchStatement"/>
     <!-- data classes aren't evil -->
     <exclude name="DataClass"/>
     <!-- would take serious refactoring in some cases -->
     <exclude name="GodClass"/>
-    <!-- we already check this ourselves -->
-    <exclude name="MissingBreakInSwitch"/>
 
     <!-- good rules, but not priority -->
     <exclude name="AvoidDeeplyNestedIfStmts"/>
-    <exclude name="ConfusingTernary"/>
     <exclude name="SwitchDensity"/>
+    <!-- these are used for readability -->
+    <exclude name="CollapsibleIfStatements"/>
   </rule>
-  <rule ref="rulesets/java/unnecessary.xml">
+  <rule ref="category/java/codestyle.xml">
     <!-- these are used for readability -->
     <exclude name="UselessParentheses"/>
+    <!-- good rules, but not priority -->
+    <exclude name="ConfusingTernary"/>
   </rule>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -551,13 +551,8 @@
                 </dependencies>
                 <configuration>
                     <rulesets>
-                        <ruleset>/rulesets/java/clone.xml</ruleset>
-                        <ruleset>/rulesets/java/finalizers.xml</ruleset>
-                        <ruleset>/rulesets/java/imports.xml</ruleset>
-                        <ruleset>/rulesets/java/logging-java.xml</ruleset>
-                        <ruleset>/rulesets/java/junit.xml</ruleset>
-                        <ruleset>/rulesets/java/migrating.xml</ruleset>
-                        <ruleset>/rulesets/java/unusedcode.xml</ruleset>
+                        <ruleset>category/java/design.xml</ruleset>
+                        <ruleset>category/java/codestyle.xml</ruleset>
                         <ruleset>${project.basedir}/etc/pmd-rules.xml</ruleset>
                     </rulesets>
                 </configuration>
@@ -677,12 +672,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.22.0</version>
+                <version>3.26.0</version>
                 <configuration>
                     <rulesets>
-                        <ruleset>/rulesets/java/basic.xml</ruleset>
-                        <ruleset>/rulesets/java/braces.xml</ruleset>
-                        <ruleset>/rulesets/java/design.xml</ruleset>
+                        <ruleset>category/java/design.xml</ruleset>
                     </rulesets>
                 </configuration>
             </plugin>


### PR DESCRIPTION
When running pmd I get the following error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.26.0:pmd (pmd) on project sb-contrib: Failed to determine whether report can be generated: Could not find resource '/rulesets/java/clone.xml'. -> [Help 1]
```

This is because PMD changed how its rulesets are structured for quite some time. See the [relevant commit in pmd](https://github.com/pmd/pmd/commit/42da2b89f2df511e4f1989f81ac006179f2b0036) and version [6.0.0](https://github.com/pmd/pmd/releases/tag/pmd_releases/6.0.0).

This PR updates maven pmd plugin to the latest version and updates the rulesets places, it also modifies the schemalocation for the pmd rules.
With the changes in this PR the pmd run is successful, and pmd finds a huge number of violations:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.26.0:check (default) on project sb-contrib: PMD 7.12.0 has found 16504 violations. For more details see: \fb-contrib\target\pmd.xml -> [Help 1]
```