### PR TITLE
update spotbugs and spotbugs mvn plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>E MMM d hh:mm:ss yyyy XX</maven.build.timestamp.format>
-        <spotbugs.version>4.9.1</spotbugs.version>
+        <spotbugs.version>4.9.3</spotbugs.version>
     </properties>
 
     <dependencyManagement>
@@ -434,7 +434,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.9.1.0</version>
+                    <version>4.9.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Updating SpotBugs and the SpotBugs maven plugin to the latest versions in maven. As far as I can see, for ant it was already updated here: https://github.com/mebigfatguy/fb-contrib/commit/93c50d097d7082805eb98ae8e2dac5dc9b25b8fe