### PR TITLE
fix FCBL_FIELD_COULD_BE_LOCAL FPs with inner classes Java 11+

### DIFF
--- a/etc/messages.xml
+++ b/etc/messages.xml
@@ -2777,7 +2777,7 @@ static {
 
 	<BugPattern type="FCBL_FIELD_COULD_BE_LOCAL">
 		<ShortDescription>Class defines fields that are used only as locals</ShortDescription>
-		<LongDescription>Class {0} defines fields that are used only as locals</LongDescription>
+		<LongDescription>The {1.name} field in class {0} is used only as a local, but defined on class level</LongDescription>
 		<Details>
 			<![CDATA[
 			<p>This class defines fields that are used in a local only fashion,

--- a/src/main/java/com/mebigfatguy/fbcontrib/detect/FieldCouldBeLocal.java
+++ b/src/main/java/com/mebigfatguy/fbcontrib/detect/FieldCouldBeLocal.java
@@ -24,13 +24,19 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.util.ClassName;
+import edu.umd.cs.findbugs.util.NestedAccessUtil;
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.Code;
+import org.apache.bcel.classfile.ConstantCP;
+import org.apache.bcel.classfile.ConstantNameAndType;
 import org.apache.bcel.classfile.ConstantPool;
 import org.apache.bcel.classfile.ConstantUtf8;
 import org.apache.bcel.classfile.Field;
@@ -43,6 +49,7 @@ import org.apache.bcel.generic.INVOKESPECIAL;
 import org.apache.bcel.generic.INVOKEVIRTUAL;
 import org.apache.bcel.generic.Instruction;
 import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.ReferenceType;
 
@@ -100,15 +107,13 @@ public class FieldCouldBeLocal extends BytecodeScanningDetector {
 			localizableFields = new HashMap<>();
 			visitedBlocks = new BitSet();
 			clsContext = classContext;
-			clsName = clsContext.getJavaClass().getClassName();
+			JavaClass cls = clsContext.getJavaClass();
+			clsName = cls.getClassName();
 
-			// this is a complete hack, but Builder pattern classes break this so just
-			// exclude so named
-			if (clsName.contains("Builder")) {
+			if (cls.isSynthetic()) {
 				return;
 			}
 			clsSig = SignatureUtils.classToSignature(clsName);
-			JavaClass cls = classContext.getJavaClass();
 			Field[] fields = cls.getFields();
 			ConstantPool cp = classContext.getConstantPoolGen().getConstantPool();
 
@@ -129,6 +134,8 @@ public class FieldCouldBeLocal extends BytecodeScanningDetector {
 			}
 
 			if (!localizableFields.isEmpty()) {
+				// if the field is referenced in nest mate classes, it can't be localized
+				removeFieldsReferencedInNestMates(cls, classContext);
 				buildMethodFieldModifiers(classContext);
 				super.visitClassContext(classContext);
 				for (FieldInfo fi : localizableFields.values()) {
@@ -148,6 +155,58 @@ public class FieldCouldBeLocal extends BytecodeScanningDetector {
 			clsContext = null;
 			methodFieldModifiers = null;
 		}
+	}
+
+	private void removeFieldsReferencedInNestMates(JavaClass cls, ClassContext classContext) {
+		if (NestedAccessUtil.hasNest(cls)) {
+			try {
+				AnalysisContext analysisContext = classContext.getAnalysisContext();
+				String className = ClassName.toSlashedClassName(cls.getClassName());
+				List<String> nestMateClassNames = NestedAccessUtil.getNestMateClassNames(cls, analysisContext);
+				for (String nestMateClassName : nestMateClassNames) {
+					JavaClass nestMateClass = analysisContext.lookupClass(nestMateClassName);
+					ConstantPool cp = nestMateClass.getConstantPool();
+					if (nestMateClass.equals(cls)) {
+						// the visited class is handled elsewhere
+						continue;
+					}
+					for (Method nestMethod : nestMateClass.getMethods()) {
+						processNestMateMethodCode(className, nestMethod.getCode(), cp);
+					}
+				}
+
+			} catch (ClassNotFoundException e) {
+				bugReporter.reportMissingClass(e);
+			}
+		}
+	}
+
+	private void processNestMateMethodCode(String visitedClass, Code methodCode, ConstantPool cp) {
+		if (methodCode != null) {
+			InstructionList instructionList = new InstructionList(methodCode.getCode());
+			for (InstructionHandle ih : instructionList) {
+				Instruction ins = ih.getInstruction();
+				if (ins instanceof FieldInstruction) {
+					FieldInstruction fins = (FieldInstruction) ins;
+					String fieldDefiningClass = getFieldDefiningClassNameFromInstruction(fins, cp);
+					if (fieldDefiningClass.equals(visitedClass)) {
+						String fieldName = getFieldNameFromInstruction(fins, cp);
+						localizableFields.remove(fieldName);
+					}
+				}
+			}
+		}
+	}
+
+	private static String getFieldNameFromInstruction(FieldInstruction fins, ConstantPool cp) {
+		ConstantCP cmr = cp.getConstant(fins.getIndex());
+		ConstantNameAndType cnat = cp.getConstant(cmr.getNameAndTypeIndex());
+		return ((ConstantUtf8)cp.getConstant(cnat.getNameIndex())).getBytes();
+	}
+
+	private static String getFieldDefiningClassNameFromInstruction(FieldInstruction fins, ConstantPool cp) {
+		ConstantCP cmr = cp.getConstant(fins.getIndex());
+		return cp.getConstantString(cmr.getClassIndex(), (byte)7);
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes #460, the FCBL_FIELD_COULD_BE_LOCAL FP part of #459, and provides a more sophisticated solution to #428 from Java version 11.
The handling of inner classes changed with [JEP 181](https://openjdk.org/jeps/181), so prior Java versions will still have FCBL_FIELD_COULD_BE_LOCAL false positives in nested classes.