### PR TITLE
[gha] remove java 11, as new Spring version does not support it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17, 21, 23]
+        java: [17, 21, 23]
         distribution: ['temurin']
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
The CI build for Java 11 broke with https://github.com/mebigfatguy/fb-contrib/commit/062a35c5f441defc959c7da03bd5a5da8f26ce13 (see [failing ci run](https://github.com/mebigfatguy/fb-contrib/actions/runs/15717072660/job/44289348006)), as Spring from 6.0.x does not support JDK 11 (see [Spring Supported Versions](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#supported-versions)). This PR removes Java 11 build from the CI to prevent unnecessary build fails.