### PR TITLE
Update CI GHA to java 25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [17, 21, 23]
+        java: [17, 21, 25]
         distribution: ['temurin']
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
Hello!

Updating the build GHA to use Java 25 instead of Java 23, as Java 25 is the latest LTS version.