### PR TITLE
update spotbugs to 4.10.2 and spotbugs-maven-plugin to 4.10.2.0 in mvn

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The group ID for sb-contrib is com.mebigfatguy.sb-contrib, and the artifact ID i
 <plugin>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-maven-plugin</artifactId>
-    <version>4.9.8.1</version>
+    <version>4.10.2.0</version>
     <configuration>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>E MMM d hh:mm:ss yyyy XX</maven.build.timestamp.format>
-        <spotbugs.version>4.9.8</spotbugs.version>
+        <spotbugs.version>4.10.2</spotbugs.version>
     </properties>
 
     <dependencyManagement>
@@ -434,7 +434,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.9.8.1</version>
+                    <version>4.10.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Updating SpotBugs and the SpotBugs maven plugin to the latest versions in maven. I have not updated for ant, as I don't have that set up, can't verify it and don't want to mess it up.

SpotBugs 4.10.2: https://github.com/spotbugs/spotbugs/releases/tag/4.10.2

compare with base version: https://github.com/spotbugs/spotbugs/compare/4.9.8...4.10.2
SpotBugs maven plugin 4.10.2.0: https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.10.2.0

compare with base version: https://github.com/spotbugs/spotbugs-maven-plugin/compare/spotbugs-maven-plugin-4.9.8.1...spotbugs-maven-plugin-4.10.2.0
I ran `./mvnw clean install -B -V --no-transfer-progress -D"license.skip=true" -D"cpd.skip=true" -D"pmd.skip=true"` on both the base branch and the PR. The build was successful, spotbugs run successfully. There were differences in the found bugs in `SpotBugsXml.xml`, which were expected.