### PR TITLE
update spotbugs to 4.10.4 and spotbugs-maven-plugin to 4.10.4.0 in mvn

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.9/apache-maven-3.8.9-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The group ID for sb-contrib is com.mebigfatguy.sb-contrib, and the artifact ID i
 <plugin>
     <groupId>com.github.spotbugs</groupId>
     <artifactId>spotbugs-maven-plugin</artifactId>
-    <version>4.10.2.0</version>
+    <version>4.10.4.0</version>
     <configuration>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>E MMM d hh:mm:ss yyyy XX</maven.build.timestamp.format>
-        <spotbugs.version>4.10.2</spotbugs.version>
+        <spotbugs.version>4.10.4</spotbugs.version>
     </properties>
 
     <dependencyManagement>
@@ -434,7 +434,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.10.2.0</version>
+                    <version>4.10.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Updating SpotBugs and the SpotBugs maven plugin to the latest versions in maven. I have not updated for ant, as I don't have that set up, can't verify it and don't want to mess it up.

SpotBugs 4.10.3: https://github.com/spotbugs/spotbugs/releases/tag/4.10.3

compare with base version: https://github.com/spotbugs/spotbugs/compare/4.10.2...4.10.3
SpotBugs maven plugin 4.10.3.0: https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.10.3.0

compare with base version: https://github.com/spotbugs/spotbugs-maven-plugin/compare/spotbugs-maven-plugin-4.10.2.0...spotbugs-maven-plugin-4.10.3.0
I ran `./mvnw clean install -B -V --no-transfer-progress -D"license.skip=true" -D"cpd.skip=true" -D"pmd.skip=true"` on both the base branch and the PR. The build was successful, spotbugs run successfully. There were no differences in the found bugs in SpotBugsXml.xml, since there weren't relevant detector changes between the two versions.